### PR TITLE
feat: Local code connector — index source files from dev repos

### DIFF
--- a/pke/api/main.py
+++ b/pke/api/main.py
@@ -41,8 +41,8 @@ class SearchResponse(BaseModel):
 
 
 class IngestRequest(BaseModel):
-    source: str  # "obsidian", "github", "discord"
-    target: str | None = None  # vault path, repo, or channel ID
+    source: str  # "obsidian", "github", "discord", "localcode"
+    target: str | None = None  # vault path, repo, channel ID, or repo path
     full: bool = False
 
 
@@ -127,6 +127,10 @@ async def ingest(req: IngestRequest):
         from pke.ingest.discord import ingest_discord
 
         stats = ingest_discord(channel_id=req.target, full=req.full)
+    elif req.source == "localcode":
+        from pke.ingest.localcode import ingest_localcode
+
+        stats = ingest_localcode(target=req.target, full=req.full)
     else:
         return IngestResponse(source=req.source, stats={"error": f"Unknown source: {req.source}"})
 
@@ -141,7 +145,7 @@ async def sources():
 
     sync = SyncState()
 
-    source_types = ["obsidian", "github", "discord"]
+    source_types = ["obsidian", "github", "discord", "localcode"]
     result = []
 
     for st in source_types:

--- a/pke/cli/main.py
+++ b/pke/cli/main.py
@@ -23,6 +23,10 @@ def cmd_ingest(args: argparse.Namespace) -> None:
         from pke.ingest.discord import ingest_discord
 
         stats = ingest_discord(channel_id=args.target, full=args.full)
+    elif source == "localcode":
+        from pke.ingest.localcode import ingest_localcode
+
+        stats = ingest_localcode(target=args.target, full=args.full)
     else:
         print(f"Unknown source: {source}", file=sys.stderr)
         sys.exit(1)
@@ -58,7 +62,7 @@ def main() -> None:
 
     # ingest
     p_ingest = sub.add_parser("ingest", help="Run ingestion pipeline")
-    p_ingest.add_argument("source", choices=["obsidian", "github", "discord"])
+    p_ingest.add_argument("source", choices=["obsidian", "github", "discord", "localcode"])
     p_ingest.add_argument("--target", help="Target path/repo/channel (source-specific)")
     p_ingest.add_argument("--full", action="store_true", help="Full re-ingestion")
     p_ingest.set_defaults(func=cmd_ingest)

--- a/pke/config.py
+++ b/pke/config.py
@@ -30,6 +30,9 @@ class Settings(BaseSettings):
     discord_bot_token: str = ""
     discord_channel_ids: str = ""  # comma-separated
 
+    # Local code repos
+    local_repos: str = ""  # comma-separated paths
+
     @property
     def github_repos_list(self) -> list[str]:
         return [r.strip() for r in self.github_repos.split(",") if r.strip()]
@@ -37,6 +40,10 @@ class Settings(BaseSettings):
     @property
     def discord_channel_ids_list(self) -> list[str]:
         return [c.strip() for c in self.discord_channel_ids.split(",") if c.strip()]
+
+    @property
+    def local_repos_list(self) -> list[str]:
+        return [r.strip() for r in self.local_repos.split(",") if r.strip()]
 
     # Sync state DB
     sync_db_path: str = "data/sync_state.db"

--- a/pke/db/setup.py
+++ b/pke/db/setup.py
@@ -43,6 +43,9 @@ def ensure_collection(client: QdrantClient | None = None) -> None:
         ("author", PayloadSchemaType.KEYWORD),
         ("url", PayloadSchemaType.KEYWORD),
         ("tags", PayloadSchemaType.KEYWORD),
+        ("repo", PayloadSchemaType.KEYWORD),
+        ("language", PayloadSchemaType.KEYWORD),
+        ("symbol_name", PayloadSchemaType.KEYWORD),
     ]:
         client.create_payload_index(
             collection_name=settings.qdrant_collection,

--- a/pke/ingest/localcode.py
+++ b/pke/ingest/localcode.py
@@ -1,0 +1,311 @@
+"""Local code ingestion pipeline — indexes source files from dev repos."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import subprocess
+from pathlib import Path
+
+from langchain_text_splitters import Language
+from qdrant_client.models import FieldCondition, Filter, FilterSelector, MatchValue, PointStruct
+
+from pke.chunk import Chunk, _make_id, chunk_code, chunk_markdown
+from pke.config import settings
+from pke.db.setup import get_client
+from pke.embed import embed_batch
+from pke.sync.state import SyncState
+
+# Directories to always skip
+SKIP_DIRS = {
+    "node_modules",
+    ".git",
+    "target",
+    "dist",
+    "build",
+    "__pycache__",
+    ".semfora",
+    ".next",
+    ".turbo",
+    "vendor",
+    ".venv",
+    "venv",
+}
+
+# Supported file extensions → Language mapping
+EXT_LANGUAGE: dict[str, Language | None] = {
+    ".ts": Language.TS,
+    ".tsx": Language.TS,
+    ".js": Language.JS,
+    ".jsx": Language.JS,
+    ".py": Language.PYTHON,
+    ".rs": Language.RUST,
+    ".md": None,  # handled separately via chunk_markdown
+}
+
+# Regex patterns for extracting symbol names per language
+_SYMBOL_PATTERNS: dict[Language, list[re.Pattern]] = {
+    Language.TS: [
+        re.compile(r"^export\s+(?:default\s+)?(?:async\s+)?function\s+(\w+)", re.MULTILINE),
+        re.compile(r"^export\s+(?:default\s+)?class\s+(\w+)", re.MULTILINE),
+        re.compile(r"^export\s+(?:default\s+)?interface\s+(\w+)", re.MULTILINE),
+        re.compile(r"^export\s+(?:default\s+)?(?:const|let)\s+(\w+)", re.MULTILINE),
+    ],
+    Language.JS: [
+        re.compile(r"^export\s+(?:default\s+)?(?:async\s+)?function\s+(\w+)", re.MULTILINE),
+        re.compile(r"^export\s+(?:default\s+)?class\s+(\w+)", re.MULTILINE),
+        re.compile(r"^export\s+(?:default\s+)?(?:const|let)\s+(\w+)", re.MULTILINE),
+    ],
+    Language.PYTHON: [
+        re.compile(r"^(?:async\s+)?def\s+(\w+)", re.MULTILINE),
+        re.compile(r"^class\s+(\w+)", re.MULTILINE),
+    ],
+    Language.RUST: [
+        re.compile(r"^pub\s+(?:async\s+)?fn\s+(\w+)", re.MULTILINE),
+        re.compile(r"^fn\s+(\w+)", re.MULTILINE),
+        re.compile(r"^pub\s+struct\s+(\w+)", re.MULTILINE),
+        re.compile(r"^pub\s+enum\s+(\w+)", re.MULTILINE),
+        re.compile(r"^impl(?:<[^>]*>)?\s+(\w+)", re.MULTILINE),
+    ],
+}
+
+
+def _file_hash(path: Path) -> str:
+    """Compute SHA256 hash of a file's contents."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _extract_symbols(text: str, language: Language) -> list[str]:
+    """Extract top-level symbol names from code text."""
+    patterns = _SYMBOL_PATTERNS.get(language, [])
+    symbols: list[str] = []
+    for pat in patterns:
+        symbols.extend(pat.findall(text))
+    return symbols
+
+
+def _get_gitignore_patterns(repo_root: Path) -> set[str]:
+    """Get ignored paths using git check-ignore, returning set of relative paths."""
+    # We'll use git ls-files to find tracked + untracked-but-not-ignored files instead
+    return set()
+
+
+def _list_code_files(repo_root: Path) -> list[Path]:
+    """List code files in a repo, respecting .gitignore and skip dirs."""
+    files: list[Path] = []
+
+    # Try using git ls-files for .gitignore respect (only if repo_root is a git repo)
+    try:
+        # Verify this is actually a git repo root
+        git_dir = repo_root / ".git"
+        if git_dir.exists() and (git_dir / "HEAD").exists():
+            result = subprocess.run(
+                ["git", "ls-files", "--cached", "--others", "--exclude-standard"],
+                cwd=repo_root,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if result.returncode == 0:
+                for line in result.stdout.strip().splitlines():
+                    if not line:
+                        continue
+                    p = repo_root / line
+                    if p.suffix in EXT_LANGUAGE and p.is_file():
+                        parts = set(Path(line).parts)
+                        if not parts & SKIP_DIRS:
+                            files.append(p)
+                return files
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+
+    # Fallback: walk manually
+    for ext in EXT_LANGUAGE:
+        for p in repo_root.rglob(f"*{ext}"):
+            parts = set(p.relative_to(repo_root).parts)
+            if not parts & SKIP_DIRS:
+                files.append(p)
+
+    return files
+
+
+def _chunk_code_file(
+    filepath: Path,
+    repo_root: Path,
+    repo_name: str,
+) -> list[Chunk]:
+    """Chunk a single code file with appropriate strategy."""
+    rel_path = str(filepath.relative_to(repo_root))
+    ext = filepath.suffix
+    language = EXT_LANGUAGE.get(ext)
+
+    try:
+        text = filepath.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+
+    if not text.strip():
+        return []
+
+    source = f"localcode:{repo_name}:{rel_path}"
+    base_meta = {
+        "source_type": "localcode",
+        "repo": repo_name,
+        "filepath": rel_path,
+        "language": ext.lstrip("."),
+    }
+
+    # Markdown files use the markdown chunker
+    if language is None and ext == ".md":
+        return chunk_markdown(text, source=source, base_metadata=base_meta)
+
+    # Code files — use langchain code splitter
+    lang = language or Language.PYTHON  # fallback
+    chunks = chunk_code(
+        text,
+        source=source,
+        language=lang,
+        base_metadata=base_meta,
+        chunk_size=1200,
+        chunk_overlap=100,
+    )
+
+    # Enrich chunks with symbol info
+    for chunk in chunks:
+        if language:
+            symbols = _extract_symbols(chunk.text, language)
+            if symbols:
+                chunk.metadata["symbol_name"] = symbols[0] if len(symbols) == 1 else ", ".join(symbols)
+
+        # Estimate line numbers from text position
+        # (approximate — good enough for search context)
+        start_idx = text.find(chunk.text[:80])
+        if start_idx >= 0:
+            line_start = text[:start_idx].count("\n") + 1
+            line_end = line_start + chunk.text.count("\n")
+            chunk.metadata["line_start"] = line_start
+            chunk.metadata["line_end"] = line_end
+
+    return chunks
+
+
+def ingest_localcode(target: str | None = None, full: bool = False) -> dict:
+    """Ingest source code from local repositories.
+
+    Args:
+        target: Specific repo path to index. If None, uses all configured repos.
+        full: If True, re-ingest everything ignoring sync state.
+
+    Returns:
+        Summary dict with counts.
+    """
+    if target:
+        repo_paths = [Path(target)]
+    else:
+        repo_paths = [Path(r) for r in settings.local_repos_list]
+
+    if not repo_paths:
+        return {"error": "No repos configured. Set PKE_LOCAL_REPOS."}
+
+    sync = SyncState()
+    client = get_client()
+    collection = settings.qdrant_collection
+    stats = {"repos": 0, "files_scanned": 0, "files_ingested": 0, "files_skipped": 0, "chunks": 0}
+
+    for repo_path in repo_paths:
+        if not repo_path.exists():
+            continue
+
+        repo_name = repo_path.name
+        stats["repos"] += 1
+
+        if full:
+            # Clear existing data for this repo
+            client.delete(
+                collection_name=collection,
+                points_selector=FilterSelector(
+                    filter=Filter(
+                        must=[
+                            FieldCondition(key="source_type", match=MatchValue(value="localcode")),
+                            FieldCondition(key="repo", match=MatchValue(value=repo_name)),
+                        ]
+                    )
+                ),
+            )
+            # Clear sync state for this repo's files
+            stored = sync.get_all("localcode")
+            for key in stored:
+                if key.startswith(f"{repo_name}:"):
+                    sync.delete("localcode", key)
+
+        stored_hashes = sync.get_all("localcode")
+        code_files = _list_code_files(repo_path)
+        stats["files_scanned"] += len(code_files)
+
+        # Track current files for deletion detection
+        current_keys: set[str] = set()
+
+        for filepath in code_files:
+            rel_path = str(filepath.relative_to(repo_path))
+            sync_key = f"{repo_name}:{rel_path}"
+            current_keys.add(sync_key)
+
+            file_h = _file_hash(filepath)
+
+            # Skip unchanged files
+            if not full and stored_hashes.get(sync_key) == file_h:
+                stats["files_skipped"] += 1
+                continue
+
+            chunks = _chunk_code_file(filepath, repo_path, repo_name)
+            if not chunks:
+                stats["files_skipped"] += 1
+                continue
+
+            # Delete old chunks for this file
+            client.delete(
+                collection_name=collection,
+                points_selector=FilterSelector(
+                    filter=Filter(
+                        must=[
+                            FieldCondition(key="source_type", match=MatchValue(value="localcode")),
+                            FieldCondition(key="repo", match=MatchValue(value=repo_name)),
+                            FieldCondition(key="filepath", match=MatchValue(value=rel_path)),
+                        ]
+                    )
+                ),
+            )
+
+            # Embed and upsert
+            vectors = embed_batch([c.text for c in chunks])
+            client.upsert(
+                collection_name=collection,
+                points=[
+                    PointStruct(id=c.id, vector=v, payload={**c.metadata, "text": c.text})
+                    for c, v in zip(chunks, vectors)
+                ],
+            )
+
+            sync.set_cursor("localcode", sync_key, file_h)
+            stats["files_ingested"] += 1
+            stats["chunks"] += len(chunks)
+
+        # Detect deleted files
+        for key in stored_hashes:
+            if key.startswith(f"{repo_name}:") and key not in current_keys:
+                rel = key[len(f"{repo_name}:"):]
+                client.delete(
+                    collection_name=collection,
+                    points_selector=FilterSelector(
+                        filter=Filter(
+                            must=[
+                                FieldCondition(key="source_type", match=MatchValue(value="localcode")),
+                                FieldCondition(key="repo", match=MatchValue(value=repo_name)),
+                                FieldCondition(key="filepath", match=MatchValue(value=rel)),
+                            ]
+                        )
+                    ),
+                )
+                sync.delete("localcode", key)
+
+    return stats

--- a/tests/test_localcode.py
+++ b/tests/test_localcode.py
@@ -1,0 +1,122 @@
+"""Tests for the local code ingestion connector."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pke.ingest.localcode import (
+    SKIP_DIRS,
+    _chunk_code_file,
+    _extract_symbols,
+    _list_code_files,
+)
+from langchain_text_splitters import Language
+
+
+@pytest.fixture
+def tmp_repo(tmp_path: Path) -> Path:
+    """Create a minimal fake repo structure."""
+    # Python file
+    (tmp_path / "main.py").write_text(
+        'def hello():\n    print("hello")\n\nclass Foo:\n    pass\n'
+    )
+    # TypeScript file
+    (tmp_path / "index.ts").write_text(
+        "export function greet(name: string): string {\n  return `Hello ${name}`;\n}\n\n"
+        "export class App {\n  run() {}\n}\n"
+    )
+    # Rust file
+    (tmp_path / "lib.rs").write_text(
+        "pub fn add(a: i32, b: i32) -> i32 {\n    a + b\n}\n\n"
+        "pub struct Config {\n    pub name: String,\n}\n"
+    )
+    # Markdown
+    (tmp_path / "README.md").write_text("# My Project\n\nSome description.\n")
+    # File that should be skipped (in node_modules)
+    nm = tmp_path / "node_modules" / "dep"
+    nm.mkdir(parents=True)
+    (nm / "index.js").write_text("module.exports = {}")
+    # .git dir should be skipped
+    gitdir = tmp_path / ".git"
+    gitdir.mkdir()
+    (gitdir / "config").write_text("[core]")
+    return tmp_path
+
+
+class TestExtractSymbols:
+    def test_python_symbols(self):
+        code = "def hello():\n    pass\n\nclass Foo:\n    pass\n"
+        symbols = _extract_symbols(code, Language.PYTHON)
+        assert "hello" in symbols
+        assert "Foo" in symbols
+
+    def test_typescript_symbols(self):
+        code = "export function greet() {}\nexport class App {}\n"
+        symbols = _extract_symbols(code, Language.TS)
+        assert "greet" in symbols
+        assert "App" in symbols
+
+    def test_rust_symbols(self):
+        code = "pub fn add() {}\npub struct Config {}\n"
+        symbols = _extract_symbols(code, Language.RUST)
+        assert "add" in symbols
+        assert "Config" in symbols
+
+    def test_empty_code(self):
+        assert _extract_symbols("", Language.PYTHON) == []
+
+
+class TestListCodeFiles:
+    def test_finds_code_files(self, tmp_repo: Path):
+        files = _list_code_files(tmp_repo)
+        names = {f.name for f in files}
+        assert "main.py" in names
+        assert "index.ts" in names
+        assert "lib.rs" in names
+        assert "README.md" in names
+
+    def test_skips_node_modules(self, tmp_repo: Path):
+        files = _list_code_files(tmp_repo)
+        rel_paths = [str(f.relative_to(tmp_repo)) for f in files]
+        assert not any("node_modules" in p for p in rel_paths)
+
+    def test_skips_git_dir(self, tmp_repo: Path):
+        files = _list_code_files(tmp_repo)
+        rel_paths = [str(f.relative_to(tmp_repo)) for f in files]
+        assert not any(".git" in p for p in rel_paths)
+
+
+class TestChunkCodeFile:
+    def test_chunks_python(self, tmp_repo: Path):
+        chunks = _chunk_code_file(tmp_repo / "main.py", tmp_repo, "test-repo")
+        assert len(chunks) > 0
+        assert all(c.metadata["source_type"] == "localcode" for c in chunks)
+        assert all(c.metadata["repo"] == "test-repo" for c in chunks)
+        assert all(c.metadata["language"] == "py" for c in chunks)
+
+    def test_chunks_typescript(self, tmp_repo: Path):
+        chunks = _chunk_code_file(tmp_repo / "index.ts", tmp_repo, "test-repo")
+        assert len(chunks) > 0
+        assert all(c.metadata["language"] == "ts" for c in chunks)
+
+    def test_chunks_markdown(self, tmp_repo: Path):
+        chunks = _chunk_code_file(tmp_repo / "README.md", tmp_repo, "test-repo")
+        assert len(chunks) > 0
+        assert all(c.metadata["source_type"] == "localcode" for c in chunks)
+
+    def test_empty_file_returns_empty(self, tmp_repo: Path):
+        empty = tmp_repo / "empty.py"
+        empty.write_text("")
+        chunks = _chunk_code_file(empty, tmp_repo, "test-repo")
+        assert chunks == []
+
+
+class TestSkipDirs:
+    def test_expected_dirs_in_skip_set(self):
+        assert "node_modules" in SKIP_DIRS
+        assert ".git" in SKIP_DIRS
+        assert "target" in SKIP_DIRS
+        assert "__pycache__" in SKIP_DIRS
+        assert ".semfora" in SKIP_DIRS


### PR DESCRIPTION
## Summary

Adds a new `localcode` connector that indexes source code files from local dev repositories into the PKE knowledge base.

### What's included

- **`pke/ingest/localcode.py`** — New connector that:
  - Walks configured repo directories for code files (`.ts`, `.tsx`, `.js`, `.jsx`, `.py`, `.rs`, `.md`)
  - Skips `node_modules/`, `.git/`, `target/`, `dist/`, `build/`, `__pycache__/`, `.semfora/`
  - Uses langchain's language-aware code splitter per file type
  - Extracts symbol names (functions, classes, structs, impls) via regex
  - Tracks file hashes for incremental sync
  - Respects `.gitignore` via `git ls-files` with manual walk fallback
  - Metadata per chunk: `repo`, `filepath`, `language`, `symbol_name`, `line_start`, `line_end`

- **Config**: `PKE_LOCAL_REPOS` env var (comma-separated paths)
- **API**: `POST /ingest {"source": "localcode"}` and `POST /ingest {"source": "localcode", "target": "/path/to/repo"}`
- **CLI**: `pke ingest localcode [--target /path] [--full]`
- **DB**: Added payload indexes for `repo`, `language`, `symbol_name`
- **Tests**: 12 new tests covering symbol extraction, file listing, chunking, and skip dirs

### Not included (noted for future)
- K8s volume mount for `/home/kadajett/dev` (infra change, separate task)
- tree-sitter parsing (regex fallback is fine for v1)

Addresses issue #7